### PR TITLE
feat: add link to CI job and bump snyk-delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ OR
 
 2. Call snyk-prevent-gh-commit-status module or binary with the following arguments:
 
+The link to CI Job is strongly recommended as it guides developers to the result set in the CI job.
+Enhancements are coming up to improve visibility and clarity on the issues findings.
+
 ```
 snyk-prevent-gh-commit-status-linux
  /path/to/snykTestResults.json 
@@ -25,6 +28,7 @@ snyk-prevent-gh-commit-status-linux
  <GH_ORG_NAME> 
  <GH_REPO_NAME> 
  <GH_COMMIT_SHA1>
+ <LINK_TO_CI_JOB - optional>
 ```
 ### Snyk CLI in bash
 ```
@@ -35,6 +39,7 @@ snyk-prevent-gh-commit-status-linux
     <GH_ORG_NAME> 
     <GH_REPO_NAME> 
     <CIRCLE_SHA1>
+    <LINK_TO_CI_JOB - optional>
 ```
 
 ### Snyk CLI in bash using npx
@@ -46,6 +51,7 @@ snyk-prevent-gh-commit-status-linux
     <GH_ORG_NAME> 
     <GH_REPO_NAME> 
     <CIRCLE_SHA1>
+    <LINK_TO_CI_JOB - optional>
 ```
 
 ### Circle CI
@@ -58,7 +64,7 @@ Example in CircleCI using an Orb for a Go Modules project [example PR](https://g
         monitor-on-build: false
         token-variable: SNYK_TOKEN
         additional-arguments: --json-file-output=snykTestResults.json
-    - run: ./snyk-prevent-gh-commit-status-linux ./snykTestResults.json ${GITHUB_TOKEN} ${CIRCLE_PROJECT_USERNAME} ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_SHA1}
+    - run: ./snyk-prevent-gh-commit-status-linux ./snykTestResults.json ${GITHUB_TOKEN} ${CIRCLE_PROJECT_USERNAME} ${CIRCLE_PROJECT_REPONAME} ${CIRCLE_SHA1} ${CIRCLE_BUILD_URL}
 ```
 
 More CI examples soon
@@ -68,11 +74,12 @@ export GH_API='https://ghe-hostname/apiendpoint'
 
 #### Additional option - Debug
 ```
+export SNYK_DEBUG=true
 ./snyk-prevent-gh-commit-status-linux 
     ./snykTestResults.json 
     <GITHUB_TOKEN> 
     <GH_ORG_NAME> 
     <GH_REPO_NAME> 
     <CIRCLE_SHA1>
-    debug
+    <LINK_TO_CI_JOB - optional>
 ```

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -29,7 +29,8 @@ const main = async () => {
     const ghOrg = process.argv.slice(2)[2];
     const ghRepo = process.argv.slice(2)[3];
     const ghSha = process.argv.slice(2)[4];
-    const debug = process.argv.slice(2)[5] == 'debug' ? true : false;
+    const detailsLink = process.argv.slice(2)[5] || '';
+    const debug = process.env.SNYK_DEBUG ? true : false// process.argv.slice(2)[6] == 'debug' ? true : false;
     const jsonResultsFromSnykTest = fs
       .readFileSync(jsonResultsFilePath)
       .toString();
@@ -57,7 +58,9 @@ const main = async () => {
           description: 'Could not find project ID. Verify org tested against',
           context: `Snyk Prevent (${orgName} - ${targetFile})`,
       }
-      if(projectID != ''){
+      if(detailsLink != ''){
+        data.target_url = detailsLink
+      } else if(projectID != ''){
         data.target_url = `https://app.snyk.io/org/${orgName}/project/${projectID}`
       }
   

--- a/test/fixtures/snyktest-gomod-all-projects-with-unmonitored-project.json
+++ b/test/fixtures/snyktest-gomod-all-projects-with-unmonitored-project.json
@@ -1,0 +1,314 @@
+[
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 8,
+    "org": "Playground",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.16.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AGPL-1.0": {
+          "licenseType": "AGPL-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "AGPL-3.0": {
+          "licenseType": "AGPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Artistic-1.0": {
+          "licenseType": "Artistic-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "Artistic-2.0": {
+          "licenseType": "Artistic-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CDDL-1.0": {
+          "licenseType": "CDDL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CPOL-1.02": {
+          "licenseType": "CPOL-1.02",
+          "severity": "high",
+          "instructions": ""
+        },
+        "EPL-1.0": {
+          "licenseType": "EPL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "GPL-2.0": {
+          "licenseType": "GPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "GPL-3.0": {
+          "licenseType": "GPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "LGPL-2.0": {
+          "licenseType": "LGPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-2.1": {
+          "licenseType": "LGPL-2.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-3.0": {
+          "licenseType": "LGPL-3.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-1.1": {
+          "licenseType": "MPL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-2.0": {
+          "licenseType": "MPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MS-RL": {
+          "licenseType": "MS-RL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "SimPL-2.0": {
+          "licenseType": "SimPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    },
+    "packageManager": "gomodules",
+    "projectId": "09235fa4-c241-42c6-8c63-c053bd272786",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "targetFile": "go.mod",
+    "projectName": "github.com/snyk-tech-services/ira-tickets-for-new-vulns",
+    "foundProjectCount": 1,
+    "displayTargetFile": "go.mod",
+    "path": "/home/antoine/Documents/SnykTSDev/jira-tickets-for-new-vulns/snyk-tech-services/ira-tickets-for-new-vulns"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 8,
+    "org": "Playground",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.16.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AGPL-1.0": {
+          "licenseType": "AGPL-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "AGPL-3.0": {
+          "licenseType": "AGPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Artistic-1.0": {
+          "licenseType": "Artistic-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "Artistic-2.0": {
+          "licenseType": "Artistic-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CDDL-1.0": {
+          "licenseType": "CDDL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CPOL-1.02": {
+          "licenseType": "CPOL-1.02",
+          "severity": "high",
+          "instructions": ""
+        },
+        "EPL-1.0": {
+          "licenseType": "EPL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "GPL-2.0": {
+          "licenseType": "GPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "GPL-3.0": {
+          "licenseType": "GPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "LGPL-2.0": {
+          "licenseType": "LGPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-2.1": {
+          "licenseType": "LGPL-2.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-3.0": {
+          "licenseType": "LGPL-3.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-1.1": {
+          "licenseType": "MPL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-2.0": {
+          "licenseType": "MPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MS-RL": {
+          "licenseType": "MS-RL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "SimPL-2.0": {
+          "licenseType": "SimPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    },
+    "packageManager": "gomodules",
+    "projectId": "09235fa4-c241-42c6-8c63-c053bd272787",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "targetFile": "go.mod",
+    "projectName": "github.com/snyk-tech-services/ira-tickets-for-new-vulns2",
+    "foundProjectCount": 1,
+    "displayTargetFile": "go.mod",
+    "path": "/home/antoine/Documents/SnykTSDev/jira-tickets-for-new-vulns/snyk-tech-services/ira-tickets-for-new-vulns2"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 8,
+    "org": "Playground",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.16.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AGPL-1.0": {
+          "licenseType": "AGPL-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "AGPL-3.0": {
+          "licenseType": "AGPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Artistic-1.0": {
+          "licenseType": "Artistic-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "Artistic-2.0": {
+          "licenseType": "Artistic-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CDDL-1.0": {
+          "licenseType": "CDDL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CPOL-1.02": {
+          "licenseType": "CPOL-1.02",
+          "severity": "high",
+          "instructions": ""
+        },
+        "EPL-1.0": {
+          "licenseType": "EPL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "GPL-2.0": {
+          "licenseType": "GPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "GPL-3.0": {
+          "licenseType": "GPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "LGPL-2.0": {
+          "licenseType": "LGPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-2.1": {
+          "licenseType": "LGPL-2.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-3.0": {
+          "licenseType": "LGPL-3.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-1.1": {
+          "licenseType": "MPL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-2.0": {
+          "licenseType": "MPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MS-RL": {
+          "licenseType": "MS-RL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "SimPL-2.0": {
+          "licenseType": "SimPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    },
+    "packageManager": "gomodules",
+    "projectId": "09235fa4-c241-42c6-8c63-c053bd272788",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "targetFile": "go.mod",
+    "projectName": "github.com/snyk-tech-services/ira-tickets-for-new-vulns-unmonitored",
+    "foundProjectCount": 1,
+    "displayTargetFile": "go.mod",
+    "path": "/home/antoine/Documents/SnykTSDev/jira-tickets-for-new-vulns/snyk-tech-services/ira-tickets-for-new-vulns-unmonitored"
+  }
+]

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -95,6 +95,7 @@ describe('Testing behaviors', () => {
   });
 
   test('Is it working in debug?', async () => {
+    process.env.SNYK_DEBUG = 'true';
     process.argv = [
       '',
       '',
@@ -103,7 +104,7 @@ describe('Testing behaviors', () => {
       '123',
       '123',
       '123',
-      'debug',
+      '',
     ];
     const response = await main();
     expect(response).toEqual([
@@ -114,6 +115,85 @@ describe('Testing behaviors', () => {
         // eslint-disable-next-line
         target_url:
           'https://app.snyk.io/org/Playground/project/09235fa4-c241-42c6-8c63-c053bd272786',
+      },
+    ]);
+    delete process.env.SNYK_DEBUG;
+  });
+
+  test('Is it working with --all-projects and unmonitored projects?', async () => {
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') +
+        '/fixtures/snyktest-gomod-all-projects-with-unmonitored-project.json',
+      '123',
+      '123',
+      '123',
+      '123',
+      'https://job123',
+    ];
+    const response = await main();
+    expect(response).toEqual([
+      {
+        context: 'Snyk Prevent (Playground - go.mod)',
+        description: 'No new issue found',
+        state: 'success',
+        // eslint-disable-next-line
+        target_url: 'https://job123',
+      },
+      {
+        context: 'Snyk Prevent (Playground - go.mod)',
+        description: 'No new issue found',
+        state: 'success',
+        // eslint-disable-next-line
+        target_url: 'https://job123',
+      },
+      {
+        context: 'Snyk Prevent (Playground - go.mod)',
+        description: 'No new issue found',
+        state: 'success',
+        // eslint-disable-next-line
+        target_url: 'https://job123',
+      },
+    ]);
+  });
+
+  test('Is it working with --all-projects and unmonitored projects without job link?', async () => {
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') +
+        '/fixtures/snyktest-gomod-all-projects-with-unmonitored-project.json',
+      '123',
+      '123',
+      '123',
+      '123',
+    ];
+    const response = await main();
+    expect(response).toEqual([
+      {
+        context: 'Snyk Prevent (Playground - go.mod)',
+        description: 'No new issue found',
+        state: 'success',
+        // eslint-disable-next-line
+        target_url:
+          'https://app.snyk.io/org/Playground/project/09235fa4-c241-42c6-8c63-c053bd272786',
+      },
+      {
+        context: 'Snyk Prevent (Playground - go.mod)',
+        description: 'No new issue found',
+        state: 'success',
+        // eslint-disable-next-line
+        target_url:
+          'https://app.snyk.io/org/Playground/project/09235fa4-c241-42c6-8c63-c053bd272787',
+      },
+      {
+        context: 'Snyk Prevent (Playground - go.mod)',
+        description: 'No new issue found',
+        state: 'success',
+        // eslint-disable-next-line
+        target_url:
+          'https://app.snyk.io/org/Playground/project/09235fa4-c241-42c6-8c63-c053bd272788',
       },
     ]);
   });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bumps to snyk-delta@1.3.0 to benefit of the new behavior returning snyk test results if no monitored project can be found (acting as passthrough instead of throwing error).
Allows a link to the CI Job to be passed to the commit status so clicking on details takes you to the CI job for more actionability.

