### PR TITLE
fix: use displayTargetFile if targetFile is missing

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -50,7 +50,7 @@ const main = async () => {
       const parsedCurrentResults = JSON.parse(currentResults)
       const orgName = parsedCurrentResults.org;
       const projectID = parsedCurrentResults.projectId || '';
-      const targetFile = parsedCurrentResults.targetFile;
+      const targetFile = parsedCurrentResults.targetFile || parsedCurrentResults.displayTargetFile || 'TargetFile not found';
   
       let data: ghCommitStatus = {
           state: ghCommitStatusState.pending,

--- a/test/fixtures/snyktest-gomod-displayTargetFile.json
+++ b/test/fixtures/snyktest-gomod-displayTargetFile.json
@@ -1,0 +1,103 @@
+{
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 8,
+    "org": "Playground",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.16.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AGPL-1.0": {
+          "licenseType": "AGPL-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "AGPL-3.0": {
+          "licenseType": "AGPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Artistic-1.0": {
+          "licenseType": "Artistic-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "Artistic-2.0": {
+          "licenseType": "Artistic-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CDDL-1.0": {
+          "licenseType": "CDDL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CPOL-1.02": {
+          "licenseType": "CPOL-1.02",
+          "severity": "high",
+          "instructions": ""
+        },
+        "EPL-1.0": {
+          "licenseType": "EPL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "GPL-2.0": {
+          "licenseType": "GPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "GPL-3.0": {
+          "licenseType": "GPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "LGPL-2.0": {
+          "licenseType": "LGPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-2.1": {
+          "licenseType": "LGPL-2.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-3.0": {
+          "licenseType": "LGPL-3.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-1.1": {
+          "licenseType": "MPL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-2.0": {
+          "licenseType": "MPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MS-RL": {
+          "licenseType": "MS-RL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "SimPL-2.0": {
+          "licenseType": "SimPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    },
+    "packageManager": "gomodules",
+    "projectId": "09235fa4-c241-42c6-8c63-c053bd272786",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "projectName": "github.com/snyk-tech-services/ira-tickets-for-new-vulns",
+    "foundProjectCount": 1,
+    "displayTargetFile": "go.mod",
+    "path": "/home/antoine/Documents/SnykTSDev/jira-tickets-for-new-vulns/snyk-tech-services/ira-tickets-for-new-vulns"
+  }

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -62,6 +62,30 @@ describe('Testing behaviors', () => {
     ]);
   });
 
+  test('Is it working with displayTargetFile?', async () => {
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') +
+        '/fixtures/snyktest-gomod-displayTargetFile.json',
+      '123',
+      '123',
+      '123',
+      '123',
+    ];
+    const response = await main();
+    expect(response).toEqual([
+      {
+        context: 'Snyk Prevent (Playground - go.mod)',
+        description: 'No new issue found',
+        state: 'success',
+        // eslint-disable-next-line
+        target_url:
+          'https://app.snyk.io/org/Playground/project/09235fa4-c241-42c6-8c63-c053bd272786',
+      },
+    ]);
+  });
+
   test('Is it working with --all-projects?', async () => {
     process.argv = [
       '',


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Uses displayTargetFile is targetFile is not in the snyk test json output.

