### PR TITLE
fix: Remove the false from the upgrade path TECHSERV-1304

### DIFF
--- a/src/lib/github/prComments.ts
+++ b/src/lib/github/prComments.ts
@@ -68,6 +68,9 @@ const formatPRComment = (snykDeltaResults: SnykDeltaOutput): string => {
 
         if (vuln.isUpgradable) {
           const upgradePaths = vuln.upgradePath;
+          if (upgradePaths && !upgradePaths[0]) {
+            upgradePaths.shift();
+          }
           const filteredUpgradedPath = upgradePaths? upgradePaths.join('=>'):'';
           vulnerabilityLine += `\t+ Fixable by upgrade: ${filteredUpgradedPath}\n`;
         }

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -323,7 +323,7 @@ describe('Testing behaviors with issue(s)', () => {
 * 1/1: Regular Expression Denial of Service (ReDoS) [High Severity]
 \t+ Via:   goof@0.0.3 => express-fileupload@0.0.5 => @snyk/nodejs-runtime-agent@1.14.0 => acorn@5.7.3
 \t+ Fixed in: acorn, 5.7.4, 6.4.1, 7.1.1
-\t+ Fixable by upgrade: false=>@snyk/nodejs-runtime-agent@1.14.0=>acorn@5.7.4
+\t+ Fixable by upgrade: @snyk/nodejs-runtime-agent@1.14.0=>acorn@5.7.4
 `,
         },
         /* eslint-enable no-useless-escape */
@@ -373,7 +373,7 @@ describe('Testing behaviors with issue(s)', () => {
 * 1/1: Regular Expression Denial of Service (ReDoS) [High Severity]
 \t+ Via:   goof@0.0.3 => express-fileupload@0.0.5 => @snyk/nodejs-runtime-agent@1.14.0 => acorn@5.7.3
 \t+ Fixed in: acorn, 5.7.4, 6.4.1, 7.1.1
-\t+ Fixable by upgrade: false=>@snyk/nodejs-runtime-agent@1.14.0=>acorn@5.7.4
+\t+ Fixable by upgrade: @snyk/nodejs-runtime-agent@1.14.0=>acorn@5.7.4
 `,
         },
         /* eslint-enable no-useless-escape */


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The false at the beginning of the upgradePath value in the comment PR was confusing.

### More information

- [Link to documentation](https://github.com/snyk/snyk-prevent-gh-commit-status/wiki/)

