### PR TITLE
Fix/add keep history option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ snyk-prevent-gh-commit-status-linux
  <GH_COMMIT_SHA1>
  <GH_PR_NUMBER>
  <LINK_TO_CI_JOB - optional>
+ <keepHistory - optional - if set the tool will post a new comment at each run otherwise it will update the existing comment>
 ```
 ### Snyk CLI in bash
 ```
@@ -42,6 +43,7 @@ snyk-prevent-gh-commit-status-linux
     <CIRCLE_SHA1>
     <GH_PR_NUMBER>
     <LINK_TO_CI_JOB - optional>
+    <keepHistory - optional>
 ```
 
 ### Snyk CLI in bash using npx
@@ -55,6 +57,7 @@ snyk-prevent-gh-commit-status-linux
     <CIRCLE_SHA1>
     <GH_PR_NUMBER>
     <LINK_TO_CI_JOB - optional>
+    <keepHistory - optional>
 ```
 
 ### Circle CI
@@ -89,6 +92,7 @@ export SNYK_DEBUG=true
     <CIRCLE_SHA1>
     <GH_PR_NUMBER>
     <LINK_TO_CI_JOB - optional>
+    <keepHistory - optional>
 ```
 
 

--- a/src/lib/github/commitStatus.ts
+++ b/src/lib/github/commitStatus.ts
@@ -46,11 +46,13 @@ export const sendCommitStatus = async (snykDeltaBinaryResult: number, snykProjec
         responseType: 'json',
         headers: { ...requestHeaders },
       });
-  
+
+
       const ghResponse = await ghClient.post(
         `/repos/${ghDetails.orgName}/${ghDetails.repoName}/statuses/${ghDetails.commitSha}`,
         JSON.stringify(data),
       );
+
 
       return ghResponse.data as ghCommitStatus
 }

--- a/src/lib/github/prComments.ts
+++ b/src/lib/github/prComments.ts
@@ -2,62 +2,8 @@ import { SnykDeltaOutput } from 'snyk-delta';
 import { ghDetails, ghPrCommentsStatus } from './types';
 import axios from 'axios';
 import * as _ from 'lodash';
-import { map } from 'lodash';
 
-export const createPrComment = async (
-  snykDeltaResults: SnykDeltaOutput,
-  ghDetails: ghDetails, 
-  keepHistory: boolean
-): Promise<ghPrCommentsStatus> => {
-  const data = {body: `${formatPRComment(snykDeltaResults)}`};
-
-  const requestHeaders: Object = {
-    'Content-Type': 'application/json',
-    Authorization: `token ${ghDetails.token}`,
-  };
-
-  const baseUrl = process.env.GH_API || 'https://api.github.com';
-
-  const ghClient = axios.create({
-    baseURL: baseUrl,
-    responseType: 'json',
-    headers: { ...requestHeaders },
-  });
-
-  let ghResponse;
-  let firstComment = false;
-  let commentUrl = '';
-
-  ghResponse = await ghClient.get(
-    `/repos/${ghDetails.orgName}/${ghDetails.repoName}/issues/${ghDetails.prNumber}/comments`
-  );
-
-  if (ghResponse.data.length === 0) {
-    firstComment = true
-  } else {
-    ghResponse.data.map((comments: any) => {
-      comments.body.includes('******* Vulnerabilities report of the')
-      commentUrl = comments.url
-    }) 
-  }
-  
-  if (keepHistory == true || firstComment == true)
-  {
-    ghResponse = await ghClient.post(
-      `/repos/${ghDetails.orgName}/${ghDetails.repoName}/issues/${ghDetails.prNumber}/comments`,
-      JSON.stringify(data),
-  );
-  } else {
-    ghResponse = await ghClient.patch(
-      commentUrl,
-      JSON.stringify(data),
-    );
-  }
-
-  return ghResponse.data as ghPrCommentsStatus
-};
-
-const formatPRComment = (snykDeltaResults: SnykDeltaOutput): string => {
+const formatPRComment = (snykDeltaResults: SnykDeltaOutput, commitNb: string): string => {
   const newVulns = snykDeltaResults.newVulns || [];
   const newLicenseIssues = snykDeltaResults.newLicenseIssues || [];
 
@@ -66,12 +12,12 @@ const formatPRComment = (snykDeltaResults: SnykDeltaOutput): string => {
   let vulnerabilityLine = '';
   let licenseLine = '';
 
-  allIssuesToDisplay = `### ******* Vulnerabilities report of the  *******\n` 
+  allIssuesToDisplay = `### ******* Vulnerabilities report for commit number ${commitNb} *******\n` 
 
   if (newVulns.length + newLicenseIssues.length > 1) {
-    allIssuesToDisplay += '# New Issues Introduced!\n';
+    allIssuesToDisplay += 'New Issues Introduced!\n';
   } else {
-    allIssuesToDisplay += '# New Issue Introduced!\n';
+    allIssuesToDisplay += 'New Issue Introduced!\n';
   }
 
   // New Vulnerability
@@ -86,7 +32,7 @@ const formatPRComment = (snykDeltaResults: SnykDeltaOutput): string => {
         vuln.title
       } [${_.capitalize(vuln.severity)} Severity]\n`;
 
-      let paths = vuln.from as Array<string>;
+      const paths = vuln.from as Array<string>;
 
       vulnerabilityLine += `\t+ Via:   ${paths.join(' => ')}\n`;
 
@@ -137,3 +83,61 @@ const formatPRComment = (snykDeltaResults: SnykDeltaOutput): string => {
 
   return allIssuesToDisplay;
 };
+
+
+export const createPrComment = async (
+  snykDeltaResults: SnykDeltaOutput,
+  ghDetails: ghDetails, 
+  keepHistory: boolean
+): Promise<ghPrCommentsStatus> => {
+
+  const data = {body: `${formatPRComment(snykDeltaResults, (ghDetails.commitSha ? ghDetails.commitSha : ''))}`};
+
+  const requestHeaders: Record<string, any> = {
+    'Content-Type': 'application/json',
+    Authorization: `token ${ghDetails.token}`,
+  };
+
+  const baseUrl = process.env.GH_API || 'https://api.github.com';
+
+  const ghClient = axios.create({
+    baseURL: baseUrl,
+    responseType: 'json',
+    headers: { ...requestHeaders },
+  });
+
+  let ghResponse;
+  let firstComment = false;
+  let commentUrl = '';
+
+  ghResponse = await ghClient.get(
+    `/repos/${ghDetails.orgName}/${ghDetails.repoName}/issues/${ghDetails.prNumber}/comments`
+  );
+
+  if (ghResponse.data.length === 0) {
+    firstComment = true
+  } else {
+    ghResponse.data.map((comments: any) => {
+      if (comments.body.includes('******* Vulnerabilities report for commit')) 
+      {
+        commentUrl = comments.url
+      }
+    }) 
+  }
+  
+  if (keepHistory == true || firstComment == true)
+  {
+    ghResponse = await ghClient.post(
+      `/repos/${ghDetails.orgName}/${ghDetails.repoName}/issues/${ghDetails.prNumber}/comments`,
+      JSON.stringify(data),
+  );
+  } else {
+    ghResponse = await ghClient.patch(
+      commentUrl,
+      JSON.stringify(data),
+    );
+  }
+
+  return ghResponse.data as ghPrCommentsStatus
+};
+

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,13 +14,20 @@ const main = async () => {
       console.log('error missing argument');
       process.exit(2);
     }
+
     const jsonResultsFilePath = process.argv.slice(2)[0];
     const ghToken = process.argv.slice(2)[1];
     const ghOrg = process.argv.slice(2)[2];
     const ghRepo = process.argv.slice(2)[3];
     const ghSha = process.argv.slice(2)[4];
     const ghPRNumber = process.argv.slice(2)[5] || '';
-    const detailsLink = process.argv.slice(2)[6] || '';
+    let keepHistory = false;
+    let detailsLink = '';
+    if (process.argv.slice(2)[6] == 'keepHistory' || process.argv.slice(2)[7] == 'keepHistory') { 
+      keepHistory = true 
+    } else { 
+      detailsLink = process.argv.slice(2)[6] || ''
+    }
 
     const debug = process.env.SNYK_DEBUG ? true : false; // process.argv.slice(2)[6] == 'debug' ? true : false;
     const jsonResultsFromSnykTest = fs
@@ -75,8 +82,11 @@ const main = async () => {
           const ghCommitStatusUpdateResponse = await sendCommitStatus(
             snykDeltaResults.result,
             snykProjectDetails,
-            githubDetails,
+            githubDetails
           );
+
+
+          
 
           let shouldCommentPr = false;
           if (snykDeltaResults.result > 0 && ghPRNumber) {
@@ -84,7 +94,7 @@ const main = async () => {
           }
 
           const ghPrCommentsCreateResponse = shouldCommentPr
-            ? await createPrComment(snykDeltaResults, githubDetails)
+            ? await createPrComment(snykDeltaResults, githubDetails, keepHistory)
             : {};
 
           responseArray.push({
@@ -92,7 +102,7 @@ const main = async () => {
             prComment: ghPrCommentsCreateResponse,
           });
         } catch (err) {
-          console.error(err.message);
+          console.error(err);
         }
       } else {
         throw new Error(`Unexpected error - undefined snyk delta result`);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -85,9 +85,6 @@ const main = async () => {
             githubDetails
           );
 
-
-          
-
           let shouldCommentPr = false;
           if (snykDeltaResults.result > 0 && ghPRNumber) {
             shouldCommentPr = true;
@@ -102,7 +99,7 @@ const main = async () => {
             prComment: ghPrCommentsCreateResponse,
           });
         } catch (err) {
-          console.error(err);
+          console.error(err.message);
         }
       } else {
         throw new Error(`Unexpected error - undefined snyk delta result`);

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -38,6 +38,8 @@ beforeAll(() => {
           return requestBody;
         case '/repos/123/123/issues/123/comments':
           return requestBody;
+        case '/repos/123/123/issues/123/comments/1':
+          return requestBody;
         default:
           throw new Error('unexpected status POSTing to Github');
       }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add an option to keep comment history, off by default => by default the PR comment will be updated each time it runs 

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Link to documentation](https://github.com/snyk/snyk-prevent-gh-commit-status/wiki/)

### Screenshots

_Visuals that may help the reviewer_
