### PR TITLE
fix: fix comment on unmonitored project with no vulns

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -98,11 +98,14 @@ const main = async () => {
             shouldCommentPr = true;
           }
 
-          if((snykDeltaResults.passIfNoBaseline && snykDeltaResults.noBaseline) === true && snykDeltaResults.result === 0
-            && (snykDeltaResults.newVulns || snykDeltaResults.newLicenseIssues))
+          if((snykDeltaResults.passIfNoBaseline && snykDeltaResults.noBaseline) === true && snykDeltaResults.result === 0)
           {
-            shouldCommentPr = true;
-            noBaseline = true
+            if (((snykDeltaResults.newVulns) && (snykDeltaResults.newVulns.length > 0)) || 
+            ((snykDeltaResults.newLicenseIssues) && (snykDeltaResults.newLicenseIssues.length > 0))) 
+            {
+              shouldCommentPr = true;
+              noBaseline = true
+            }
           }
 
           const ghCommitStatusUpdateResponse = await sendCommitStatus(

--- a/test/fixtures/snyktest-gomod-unmonitored.json
+++ b/test/fixtures/snyktest-gomod-unmonitored.json
@@ -1,0 +1,103 @@
+{
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 8,
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.16.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "org": "playground",
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AGPL-1.0": {
+          "licenseType": "AGPL-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "AGPL-3.0": {
+          "licenseType": "AGPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Artistic-1.0": {
+          "licenseType": "Artistic-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "Artistic-2.0": {
+          "licenseType": "Artistic-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CDDL-1.0": {
+          "licenseType": "CDDL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CPOL-1.02": {
+          "licenseType": "CPOL-1.02",
+          "severity": "high",
+          "instructions": ""
+        },
+        "EPL-1.0": {
+          "licenseType": "EPL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "GPL-2.0": {
+          "licenseType": "GPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "GPL-3.0": {
+          "licenseType": "GPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "LGPL-2.0": {
+          "licenseType": "LGPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-2.1": {
+          "licenseType": "LGPL-2.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-3.0": {
+          "licenseType": "LGPL-3.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-1.1": {
+          "licenseType": "MPL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-2.0": {
+          "licenseType": "MPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MS-RL": {
+          "licenseType": "MS-RL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "SimPL-2.0": {
+          "licenseType": "SimPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    },
+    "packageManager": "gomodules",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "targetFile": "go.mod",
+    "projectName": "ira-tickets-for-new-vulns",
+    "foundProjectCount": 1,
+    "displayTargetFile": "go.mod",
+    "path": "/home/antoine/Documents/SnykTSDev/jira-tickets-for-new-vulns/snyk-tech-services/ira-tickets-for-new-vulns"
+  }

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -320,6 +320,34 @@ describe('Testing behaviors without issue', () => {
       },
     ]);
   });
+
+  test('[snyk-delta module] Is it working with unmonitored project and no vuln?', async () => {
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') +
+        '/fixtures/snyktest-gomod-unmonitored.json',
+      '123',
+      '123',
+      '123',
+      '123',
+      '123',
+      'setPassIfNoBaselineFlag',
+    ];
+    const response = await main();
+    expect(response).toEqual([
+      {
+        status: {
+          context: 'Snyk Prevent (playground - go.mod)',
+          description: 'No new issue found',
+          state: 'success',
+          // eslint-disable-next-line
+          target_url: 'https://app.snyk.io/org/playground/projects',
+        },
+        prComment: {},
+      },
+    ]);
+  });
 });
 
 describe('Testing behaviors with issue(s)', () => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

_Explain why this PR exists_

Snyk delta send empty array when there is no vuls, adding a length check to comment the project only if there are vuln.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Link to documentation](https://github.com/snyk/snyk-prevent-gh-commit-status/wiki/)

### Screenshots

_Visuals that may help the reviewer_
