### PR TITLE
feat: add failon flags following failon support in snyk-delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ snyk-prevent-gh-commit-status-linux
  <GH_PR_NUMBER>
  <LINK_TO_CI_JOB - optional>
  <keepHistory - optional - if set the tool will post a new comment at each run otherwise it will update the existing comment>
+ <failOn value - optional - if set, the commit status fails only if there are issues fixable by upgrade or patch or both.
 ```
 ### Snyk CLI in bash
 ```
@@ -102,6 +103,10 @@ export SNYK_DEBUG=true
 #### No baseline
 In case of an unmonitored project, it is possible to force the snyk-delta result so snyk-prevent-gh-commit-status will not fail.
 If some vulnerabilities are found comment listing the vulnerabilities will still be the post on the PR.
+
+#### Fail on
+If set, the commit status fails only if there are issues fixable by upgrade or patch or both.
+See [Snyk CLI documentation](https://docs.snyk.io/snyk-cli/test-for-vulnerabilities/advanced-failing-of-builds-in-snyk-cli) and [Snyk-delta README usage section](https://github.com/snyk-tech-services/snyk-delta#usage).
 
 #### Debug
 use DEBUG=snyk* to enable snyk-prevent-gh-commit-status

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "axios": "^0.27.2",
     "debug": "^4.1.1",
     "lodash": "^4.17.21",
-    "snyk-delta": "^1.5.8",
+    "snyk-delta": "^1.7.2",
     "snyk-config": "^4.0.0",
     "source-map-support": "^0.5.16",
     "tslib": "^1.10.0"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -26,23 +26,23 @@ const main = async () => {
     let keepHistory = false;
     let setPassIfNoBaselineFlag = false;
     let detailsLink = '';
+    let failOn = undefined
 
     const options = process.argv.slice(8)
 
     options.forEach(option => {
-      if (option === 'keepHistory')
-      {
+      if (option === 'keepHistory') {
         keepHistory = true
-      } else if (option === 'setPassIfNoBaselineFlag')
-      {
+      } else if (option === 'setPassIfNoBaselineFlag') {
         setPassIfNoBaselineFlag = true
-      } else
-      {
+      } else if(option === 'upgradable' || option === 'patchable' || option === 'all') {
+        failOn = option
+      } else {
         detailsLink = option || ''
       }
     })
 
-    debug(`running snyk-prevent-gh-commit-status with org: ${ghOrg} repo: ${ghRepo} commit: ${ghSha} PRNumber: ${ghPRNumber} keepHistory: ${keepHistory} setPassIfNoBaselineFlag: ${setPassIfNoBaselineFlag} detailsLink: ${detailsLink}`)
+    debug(`running snyk-prevent-gh-commit-status with org: ${ghOrg} repo: ${ghRepo} commit: ${ghSha} PRNumber: ${ghPRNumber} keepHistory: ${keepHistory} setPassIfNoBaselineFlag: ${setPassIfNoBaselineFlag} detailsLink: ${detailsLink} failOn: ${failOn}`)
 
     const snykDeltaDebug = process.env.SNYK_DEBUG ? true : false; // process.argv.slice(2)[6] == 'debug' ? true : false;
     const jsonResultsFromSnykTest = fs
@@ -69,6 +69,7 @@ const main = async () => {
         currentResults,
         snykDeltaDebug,
         setPassIfNoBaselineFlag,
+        failOn,
       )) as SnykDeltaOutput;
       
       const parsedCurrentResults = JSON.parse(currentResults);

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -1060,4 +1060,268 @@ New Issues Introduced!
       },
     ]);
   });
+
+  test('[snyk-delta module] Is it working with passing with failOn upgradable', async () => {
+    let response;
+
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') +
+        '/fixtures/snykTestOutput/test-goof-two-vuln-two-license.json',
+      '123',
+      '123',
+      '123',
+      '123',
+      '123',
+      'upgradable',
+    ];
+    response = await main();
+    expect(response).toEqual([
+      {
+        status: {
+          context: 'Snyk Prevent (playground - package-lock.json)',
+          description: 'New issue(s) found',
+          state: 'failure',
+          // eslint-disable-next-line
+          target_url: 'https://app.snyk.io/org/playground/projects',
+        },
+        /* eslint-disable no-useless-escape */
+        prComment: {
+          body: `### ******* Vulnerabilities report for commit number 123 *******
+New Issues Introduced!
+## Security
+1 issue found 
+* 1/1: Prototype Pollution [Medium Severity]
+\t+ Via:   goof@0.0.3 => snyk@1.228.3 => configstore@3.1.2 => dot-prop@4.2.0
+\t+ Fixed in: dot-prop, 5.1.1
+\t+ Fixable by upgrade: snyk@1.290.1
+## License
+1 issue found 
+  1/1: 
+      Artistic-2.0 license 
+      [Medium Severity]
+\t+ Via: goof@1.0.1 => npm@7.12.0
+`,
+        },
+        /* eslint-enable no-useless-escape */
+      },
+    ]);
+
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') + '/fixtures/snyktest-gomod.json',
+      '123',
+      '123',
+      '123',
+      '123',
+    ];
+    response = await main();
+    expect(response).toEqual([
+      {
+        status: {
+          context: 'Snyk Prevent (playground - go.mod)',
+          description: 'No new issue found',
+          state: 'success',
+          // eslint-disable-next-line
+          target_url:
+            'https://app.snyk.io/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786',
+        },
+        prComment: {},
+      },
+    ]);
+
+    const requestHeaders: Record<string, any> = {
+      'Content-Type': 'application/json',
+      Authorization: `token 123`,
+    };
+
+    const ghClient = axios.create({
+      baseURL: 'https://api.github.com',
+      responseType: 'json',
+      headers: { ...requestHeaders },
+    });
+
+    const commentUrl = `/repos/123/123/issues/123/comments`;
+
+    const ghResponse = await ghClient.get(commentUrl);
+
+    expect(ghResponse.data).toEqual([
+      {
+        id: 1,
+        body:
+          '### ******* Vulnerabilities report for commit number 123 *******',
+        url: 'https://api.github.com/repos/123/123/issues/123/comments/1',
+      },
+    ]);
+  });
+  test('[snyk-delta module] Is it working with failing with failOn patchable', async () => {
+    let response;
+
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') +
+        '/fixtures/snykTestOutput/test-goof-two-vuln-two-license.json',
+      '123',
+      '123',
+      '123',
+      '123',
+      '123',
+      'patchable',
+    ];
+    response = await main();
+    expect(response).toEqual([
+      {
+        status: {
+          context: 'Snyk Prevent (playground - package-lock.json)',
+          description: 'No new issue found',
+          state: 'success',
+          // eslint-disable-next-line
+          target_url: 'https://app.snyk.io/org/playground/projects',
+        },
+        /* eslint-disable no-useless-escape */
+        prComment: {},
+        /* eslint-enable no-useless-escape */
+      },
+    ]);
+
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') + '/fixtures/snyktest-gomod.json',
+      '123',
+      '123',
+      '123',
+      '123',
+    ];
+    response = await main();
+    expect(response).toEqual([
+      {
+        status: {
+          context: 'Snyk Prevent (playground - go.mod)',
+          description: 'No new issue found',
+          state: 'success',
+          // eslint-disable-next-line
+          target_url:
+            'https://app.snyk.io/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786',
+        },
+        prComment: {},
+      },
+    ]);
+
+    const requestHeaders: Record<string, any> = {
+      'Content-Type': 'application/json',
+      Authorization: `token 123`,
+    };
+
+    const ghClient = axios.create({
+      baseURL: 'https://api.github.com',
+      responseType: 'json',
+      headers: { ...requestHeaders },
+    });
+
+    const commentUrl = `/repos/123/123/issues/123/comments`;
+
+    const ghResponse = await ghClient.get(commentUrl);
+
+    expect(ghResponse.data).toEqual([]);
+  });
+
+  test('[snyk-delta module] Is it working with passing with failOn all', async () => {
+    let response;
+
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') +
+        '/fixtures/snykTestOutput/test-goof-two-vuln-two-license.json',
+      '123',
+      '123',
+      '123',
+      '123',
+      '123',
+      'all',
+    ];
+    response = await main();
+    expect(response).toEqual([
+      {
+        status: {
+          context: 'Snyk Prevent (playground - package-lock.json)',
+          description: 'New issue(s) found',
+          state: 'failure',
+          // eslint-disable-next-line
+          target_url: 'https://app.snyk.io/org/playground/projects',
+        },
+        /* eslint-disable no-useless-escape */
+        prComment: {
+          body: `### ******* Vulnerabilities report for commit number 123 *******
+New Issues Introduced!
+## Security
+1 issue found 
+* 1/1: Prototype Pollution [Medium Severity]
+\t+ Via:   goof@0.0.3 => snyk@1.228.3 => configstore@3.1.2 => dot-prop@4.2.0
+\t+ Fixed in: dot-prop, 5.1.1
+\t+ Fixable by upgrade: snyk@1.290.1
+## License
+1 issue found 
+  1/1: 
+      Artistic-2.0 license 
+      [Medium Severity]
+\t+ Via: goof@1.0.1 => npm@7.12.0
+`,
+        },
+        /* eslint-enable no-useless-escape */
+      },
+    ]);
+
+    process.argv = [
+      '',
+      '',
+      path.resolve(__dirname, '..') + '/fixtures/snyktest-gomod.json',
+      '123',
+      '123',
+      '123',
+      '123',
+    ];
+    response = await main();
+    expect(response).toEqual([
+      {
+        status: {
+          context: 'Snyk Prevent (playground - go.mod)',
+          description: 'No new issue found',
+          state: 'success',
+          // eslint-disable-next-line
+          target_url:
+            'https://app.snyk.io/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786',
+        },
+        prComment: {},
+      },
+    ]);
+
+    const requestHeaders: Record<string, any> = {
+      'Content-Type': 'application/json',
+      Authorization: `token 123`,
+    };
+
+    const ghClient = axios.create({
+      baseURL: 'https://api.github.com',
+      responseType: 'json',
+      headers: { ...requestHeaders },
+    });
+
+    const commentUrl = `/repos/123/123/issues/123/comments`;
+
+    const ghResponse = await ghClient.get(commentUrl);
+
+    expect(ghResponse.data).toEqual([
+      {
+        id: 1,
+        body:
+          '### ******* Vulnerabilities report for commit number 123 *******',
+        url: 'https://api.github.com/repos/123/123/issues/123/comments/1',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds failon support following failon capabilities [addition to snyk-delta](https://github.com/snyk-tech-services/snyk-delta/pull/124).
