### PR TITLE
Mv to use snyk-delta not relying on projects v1 endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,35 @@
 version: 2.1
+orbs:
+    snyk: snyk/snyk@1.1.2
 jobs:
     build-test-monitor:
         docker:
-            - image: circleci/node:latest
+            - image: cimg/node:18.4.0
         steps:
             - checkout
             - run: npm install semantic-release @semantic-release/exec pkg --save-dev --legacy-peer-deps
             - run: npm install
             - run: npm test
+            - snyk/scan:
+                fail-on-issues: true
+                monitor-on-build: true
+                token-variable: SNYK_TEST_TOKEN
             - run: npx semantic-release
     build-test:
         docker:
-            - image: circleci/node:latest
+            - image: cimg/node:18.4.0
         steps:
             - checkout
             - run: npm install
             - run: npm test
+            - snyk/scan:
+                fail-on-issues: true
+                monitor-on-build: false
+                token-variable: SNYK_TEST_TOKEN
             - run: npx tsc
     build-test-from-fork:
         docker:
-            - image: circleci/node:latest
+            - image: cimg/node:18.4.0
         steps:
             - checkout
             - run: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
     build-test-monitor:
         docker:
-            - image: cimg/node:18.4.0
+            - image: cimg/node:16.20.1
         steps:
             - checkout
             - run: npm install semantic-release @semantic-release/exec pkg --save-dev --legacy-peer-deps

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-watch": "tsc -w",
     "prepare": "npm run build",
     "snyk-test": "snyk test",
-    "pkg-binaries": "npx pkg . -t node12-linux-x64,node12-macos-x64,node12-win-x64 --out-path ./dist/binaries"
+    "pkg-binaries": "npx pkg . -t node128-linux-x64,node18-macos-x64,node18-win-x64 --out-path ./dist/binaries"
   },
   "types": "./dist/index.d.ts",
   "repository": {
@@ -28,7 +28,7 @@
   "author": "Snyk Tech Services",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "files": [
     "dist"
@@ -36,30 +36,31 @@
   "homepage": "https://github.com/snyk-tech-services/snyk-prevent-gh-commit-status#readme",
   "dependencies": {
     "@snyk/configstore": "^3.2.0-rc1",
+    "@types/node": "^20.3.2",
     "axios": "^0.27.2",
     "debug": "^4.1.1",
     "lodash": "^4.17.21",
-    "snyk-delta": "^1.8.0",
     "snyk-config": "^4.0.0",
+    "snyk-delta": "^1.8.0",
     "source-map-support": "^0.5.16",
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@types/jest": "^25.1.1",
-    "@types/lodash": "^4.14.149",
-    "@types/node": "^12.12.26",
+    "@types/jest": "^29.5.2",
+    "@types/lodash": "4.14.182",
+    "@types/node": "^12.12.31",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
-    "jest": "^25.1.0",
+    "jest": "^29.5.0",
     "nock": "^13.0.2",
     "prettier": "^1.19.1",
     "snyk": "^1.760.0",
-    "ts-jest": "^25.1.0",
+    "ts-jest": "^29.1.1",
     "ts-node": "8.6.2",
     "tsc-watch": "^4.1.0",
-    "typescript": "^3.7.5"
+    "typescript": "^5.1.6"
   },
   "pkg": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --write '{''{lib,test}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
     "lint": "npm run format:check && npm run lint:eslint",
     "lint:eslint": "eslint --cache '{lib,test}/**/*.ts'",
-    "test": "snyk test && npm run lint && npm run test:unit",
+    "test": "npm run lint && npm run test:unit",
     "test:unit": "jest",
     "test:coverage": "npm run test:unit -- --coverage",
     "test:watch": "tsc-watch --onSuccess 'npm run test:unit'",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "snyk-prevent-gh-commit-status": "dist/index.js"
   },
   "scripts": {
-    "format:check": "prettier --check '{''{lib,test}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
-    "format": "prettier --write '{''{lib,test}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
+    "format:check": "prettier --check '{''{lib}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
+    "format": "prettier --write '{''{lib}/!(fixtures)/**/*,*}.{js,ts,json,yml}'",
     "lint": "npm run format:check && npm run lint:eslint",
     "lint:eslint": "eslint --cache '{lib,test}/**/*.ts'",
     "test": "npm run lint && npm run test:unit",
@@ -18,7 +18,7 @@
     "build-watch": "tsc -w",
     "prepare": "npm run build",
     "snyk-test": "snyk test",
-    "pkg-binaries": "npx pkg . -t node128-linux-x64,node18-macos-x64,node18-win-x64 --out-path ./dist/binaries"
+    "pkg-binaries": "npx pkg . -t node18-linux-x64,node18-macos-x64,node18-win-x64 --out-path ./dist/binaries"
   },
   "types": "./dist/index.d.ts",
   "repository": {
@@ -41,7 +41,7 @@
     "debug": "^4.1.1",
     "lodash": "^4.17.21",
     "snyk-config": "^4.0.0",
-    "snyk-delta": "^1.8.0",
+    "snyk-delta": "^1.10.0",
     "source-map-support": "^0.5.16",
     "tslib": "^1.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-watch": "tsc -w",
     "prepare": "npm run build",
     "snyk-test": "snyk test",
-    "pkg-binaries": "npx pkg . -t node18-linux-x64,node18-macos-x64,node18-win-x64 --out-path ./dist/binaries"
+    "pkg-binaries": "npx pkg . -t node16-linux-x64,node16-macos-x64,node16-win-x64 --out-path ./dist/binaries"
   },
   "types": "./dist/index.d.ts",
   "repository": {
@@ -28,7 +28,7 @@
   "author": "Snyk Tech Services",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=16"
   },
   "files": [
     "dist"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -142,7 +142,7 @@ const main = async () => {
             status: ghCommitStatusUpdateResponse,
             prComment: ghPrCommentsCreateResponse,
           });
-        } catch (err) {
+        } catch (err: any) {
           console.error(err.message);
         }
       } else {
@@ -151,8 +151,8 @@ const main = async () => {
     }
 
     return responseArray;
-  } catch (err) {
-    throw new Error(err);
+  } catch (err: any) {
+    throw new Error(err.message);
   }
 };
 

--- a/test/fixtures/api-response-org-id-from-slug.json
+++ b/test/fixtures/api-response-org-id-from-slug.json
@@ -1,0 +1,20 @@
+{
+    "data": [
+      {
+        "attributes": {
+          "group_id": "09235fa4-c241-42c6-8c63-c053bd2727ab",
+          "is_personal": false,
+          "name": "playground",
+          "slug": "playground"
+        },
+        "id": "09235fa4-c241-42c6-8c63-c053bd272780",
+        "type": "org"
+      }
+    ],
+    "jsonapi": {
+      "version": "1.0"
+    },
+    "links": {
+      "prev": "/rest/orgs?ending_before=v1.eyJuYW1lIjoiYW50b2luZSBwbGF5Z3JvdW5kIiwic2x1ZyI6ImFudG9pbmUtcGxheWdyb3VuZCJ9&limit=10&slug=customerorg&version=2023-05-29"
+    }
+  }

--- a/test/fixtures/api-response-rest-projects-all-projects.json
+++ b/test/fixtures/api-response-rest-projects-all-projects.json
@@ -1,0 +1,560 @@
+{
+    "jsonapi": {
+      "version": "1.0"
+    },
+    "data": [
+      {
+        "type": "project",
+        "id": "7c62c3bd-539a-4ee6-b1a0-1f3b5196849b",
+        "meta": {},
+        "attributes": {
+          "name": "snyk-tech-services/snyk-delta:package.json",
+          "type": "npm",
+          "target_file": "package.json",
+          "target_reference": "develop",
+          "origin": "github",
+          "created": "2023-01-10T16:37:37.804Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "daily"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "60744bad-77b8-45c2-8d7d-696f9ab54552"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/60744bad-77b8-45c2-8d7d-696f9ab54552"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      },
+      {
+        "type": "project",
+        "id": "09235fa4-c241-42c6-8c63-c053bd272789",
+        "meta": {},
+        "attributes": {
+          "name": "goof",
+          "type": "npm",
+          "target_file": "",
+          "target_reference": "master",
+          "origin": "cli",
+          "created": "2023-01-10T14:10:03.186Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "weekly"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "c1a61cbb-dd2a-4a19-a5ba-32615a7f925c"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/c1a61cbb-dd2a-4a19-a5ba-32615a7f925c"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      },
+      {
+        "type": "project",
+        "id": "0cc9d21b-4ac7-4f27-8c6a-b32b4cdf5c68",
+        "meta": {},
+        "attributes": {
+          "name": "Snyk Demo/java-goof",
+          "type": "sast",
+          "target_file": "",
+          "target_reference": "master",
+          "origin": "bitbucket-server",
+          "created": "2023-01-10T13:49:49.395Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "weekly"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "3dfebab7-c6d3-4343-a712-54bc3b02b8d2"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/3dfebab7-c6d3-4343-a712-54bc3b02b8d2"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      },
+      {
+        "type": "project",
+        "id": "38e02916-0cf7-4927-ba98-06afae9fef36",
+        "meta": {},
+        "attributes": {
+          "name": "Snyk Demo/java-goof:todolist-web-struts/pom.xml",
+          "type": "maven",
+          "target_file": "todolist-web-struts/pom.xml",
+          "target_reference": "master",
+          "origin": "bitbucket-server",
+          "created": "2023-01-10T13:49:42.637Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "daily"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "3dfebab7-c6d3-4343-a712-54bc3b02b8d2"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/3dfebab7-c6d3-4343-a712-54bc3b02b8d2"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      },
+      {
+        "type": "project",
+        "id": "019e3f03-5230-4d4f-9326-2fdc7161016f",
+        "meta": {},
+        "attributes": {
+          "name": "Snyk Demo/java-goof:todolist-core/pom.xml",
+          "type": "maven",
+          "target_file": "todolist-core/pom.xml",
+          "target_reference": "master",
+          "origin": "bitbucket-server",
+          "created": "2023-01-10T13:49:42.616Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "daily"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "3dfebab7-c6d3-4343-a712-54bc3b02b8d2"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/3dfebab7-c6d3-4343-a712-54bc3b02b8d2"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      },
+      {
+        "type": "project",
+        "id": "4737fc9c-3894-40ba-9dc5-aa8ae658c9f6",
+        "meta": {},
+        "attributes": {
+          "name": "Snyk Demo/java-goof:todolist-web-common/pom.xml",
+          "type": "maven",
+          "target_file": "todolist-web-common/pom.xml",
+          "target_reference": "master",
+          "origin": "bitbucket-server",
+          "created": "2023-01-10T13:49:42.572Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "daily"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "3dfebab7-c6d3-4343-a712-54bc3b02b8d2"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/3dfebab7-c6d3-4343-a712-54bc3b02b8d2"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      },
+      {
+        "type": "project",
+        "id": "7ae91d60-d686-4035-b94e-32159359b253",
+        "meta": {},
+        "attributes": {
+          "name": "jeff-snyk-demo/java-goof",
+          "type": "sast",
+          "target_file": "",
+          "target_reference": "master",
+          "origin": "bitbucket-server",
+          "created": "2023-01-10T13:43:11.924Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "weekly"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "a745345b-11e3-4145-84ae-d0f5aeaeae5f"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/a745345b-11e3-4145-84ae-d0f5aeaeae5f"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      },
+      {
+        "type": "project",
+        "id": "f3b2e1cf-69e2-4fab-89a0-b17e0979abc6",
+        "meta": {},
+        "attributes": {
+          "name": "jeff-snyk-demo/java-goof:todolist-web-struts/pom.xml",
+          "type": "maven",
+          "target_file": "todolist-web-struts/pom.xml",
+          "target_reference": "master",
+          "origin": "bitbucket-server",
+          "created": "2023-01-10T13:42:20.990Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "daily"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "a745345b-11e3-4145-84ae-d0f5aeaeae5f"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/a745345b-11e3-4145-84ae-d0f5aeaeae5f"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      },
+      {
+        "type": "project",
+        "id": "b9046a1a-3e69-4d21-a6d2-c71f649cb7b5",
+        "meta": {},
+        "attributes": {
+          "name": "jeff-snyk-demo/java-goof:todolist-web-common/pom.xml",
+          "type": "maven",
+          "target_file": "todolist-web-common/pom.xml",
+          "target_reference": "master",
+          "origin": "bitbucket-server",
+          "created": "2023-01-10T13:42:20.894Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "daily"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "a745345b-11e3-4145-84ae-d0f5aeaeae5f"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/a745345b-11e3-4145-84ae-d0f5aeaeae5f"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      },
+      {
+        "type": "project",
+        "id": "b4d24542-e0ee-4166-80bc-cd474c2bc968",
+        "meta": {},
+        "attributes": {
+          "name": "jeff-snyk-demo/java-goof:todolist-core/pom.xml",
+          "type": "maven",
+          "target_file": "todolist-core/pom.xml",
+          "target_reference": "master",
+          "origin": "bitbucket-server",
+          "created": "2023-01-10T13:42:20.782Z",
+          "status": "active",
+          "business_criticality": [],
+          "environment": [],
+          "lifecycle": [],
+          "tags": [],
+          "settings": {
+            "recurring_tests": {
+              "frequency": "daily"
+            },
+            "pull_requests": {
+              "fail_only_for_issues_with_fix": false
+            }
+          }
+        },
+        "relationships": {
+          "organization": {
+            "data": {
+              "type": "org",
+              "id": "361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967"
+            }
+          },
+          "target": {
+            "data": {
+              "type": "target",
+              "id": "a745345b-11e3-4145-84ae-d0f5aeaeae5f"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/targets/a745345b-11e3-4145-84ae-d0f5aeaeae5f"
+            }
+          },
+          "importer": {
+            "data": {
+              "type": "user",
+              "id": "822a3565-9b97-4960-ac2b-7313da2202ed"
+            },
+            "links": {
+              "related": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/users/822a3565-9b97-4960-ac2b-7313da2202ed"
+            }
+          }
+        }
+      }
+    ],
+    "links": {
+      "prev": "/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10&starting_after=v1.eyJpZCI6MzU2NTI5Mzd9"
+    }
+  }

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -7,33 +7,46 @@ import axios from 'axios';
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 
 beforeAll(() => {
-  return nock('https://snyk.io')
+  nock('https://api.snyk.io')
+    .persist()
+    .get(/^(?!.*xyz).*$/)
+    .reply(200, (uri) => {
+      switch (uri) {
+        case '/rest/orgs/09235fa4-c241-42c6-8c63-c053bd272780/projects?version=2023-05-29&limit=10':
+          return fs.readFileSync(
+            fixturesFolderPath + 'api-response-rest-projects-all-projects.json',
+          );
+        case '/rest/orgs?version=2023-06-22~beta&limit=10&slug=playground':
+          return fs.readFileSync(
+            fixturesFolderPath + 'api-response-org-id-from-slug.json',
+          );
+        default:
+      }
+    });
+
+  nock('https://snyk.io')
     .persist()
     .post(/^(?!.*xyz).*$/)
     .reply(200, (uri) => {
       switch (uri) {
-        case '/api/v1/org/playground/projects':
-          return fs.readFileSync(
-            fixturesFolderPath + 'api-response-projects-all-projects.json',
-          );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/aggregated-issues':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272786/aggregated-issues':
           return fs.readFileSync(
             fixturesFolderPath + 'apitest-gomod-aggregated.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/dep-graph':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272786/dep-graph':
           return fs.readFileSync(
             fixturesFolderPath + 'goof-depgraph-from-api.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272787/aggregated-issues':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272787/aggregated-issues':
           return fs.readFileSync(
             fixturesFolderPath + 'apitest-gomod-aggregated.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272789/aggregated-issues':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272789/aggregated-issues':
           return fs.readFileSync(
             fixturesFolderPath +
               '/api-response/test-goof-aggregated-one-vuln-one-license.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272790/aggregated-issues':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272790/aggregated-issues':
           return fs.readFileSync(
             fixturesFolderPath +
               '/api-response/test-goof-aggregated-one-vuln-one-license.json',
@@ -44,40 +57,40 @@ beforeAll(() => {
     .get(/^(?!.*xyz).*$/)
     .reply(200, (uri) => {
       switch (uri) {
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/dep-graph':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272786/dep-graph':
           return fs.readFileSync(
             fixturesFolderPath + 'goof-depgraph-from-api.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272787/dep-graph':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272787/dep-graph':
           return fs.readFileSync(
             fixturesFolderPath + 'goof-depgraph-from-api.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272788/dep-graph':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272788/dep-graph':
           return fs.readFileSync(
             fixturesFolderPath + 'goof-depgraph-from-api.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272790/dep-graph':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272790/dep-graph':
           return fs.readFileSync(
             fixturesFolderPath + 'goof-depgraph-from-api.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272789/dep-graph':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272789/dep-graph':
           return fs.readFileSync(
             fixturesFolderPath + 'goof-depgraph-from-api.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272789/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272789/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
           return fs.readFileSync(
             fixturesFolderPath + 'snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272789/issue/SNYK-JS-PACRESOLVER-1564857/paths?perPage=100&page=1':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272789/issue/SNYK-JS-PACRESOLVER-1564857/paths?perPage=100&page=1':
           return fs.readFileSync(
             fixturesFolderPath + 'SNYK-JS-PACRESOLVER-1564857-issue-paths.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272789/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272789/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
           return fs.readFileSync(
             fixturesFolderPath +
               'SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
           );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272789/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+        case '/api/v1/org/09235fa4-c241-42c6-8c63-c053bd272780/project/09235fa4-c241-42c6-8c63-c053bd272789/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
           return fs.readFileSync(
             fixturesFolderPath + 'SNYK-JS-ACORN-559469-issue-paths.json',
           );


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Brings snyk-delta to the minimal version required to get off the projects api v1 endpoint that is being decommissioned.

### Notes for the reviewer

No functional change, simply version upgrades and node version upgrade.