### PR TITLE
fix: release by pinning semantic release to earlier version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
             - image: cimg/node:16.20.1
         steps:
             - checkout
-            - run: npm install semantic-release @semantic-release/exec pkg --save-dev --legacy-peer-deps
+            - run: npm install semantic-release@19.0.5 @semantic-release/exec pkg --save-dev --legacy-peer-deps
             - run: npm install
             - run: npm test
             - snyk/scan:
@@ -17,7 +17,7 @@ jobs:
             - run: npx semantic-release
     build-test:
         docker:
-            - image: cimg/node:18.4.0
+            - image: cimg/node:16.20.1
         steps:
             - checkout
             - run: npm install


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Pins semantic release to a version not requiring node18. Keeps it aligned to the Snyk CLI minimal node version, currently node 16.